### PR TITLE
Feature Id now supports string and number

### DIFF
--- a/src/GeoFeature.cs
+++ b/src/GeoFeature.cs
@@ -23,7 +23,7 @@ public sealed class GeoFeature : GeoObject
     { }
 
     public GeoFeature(
-        string? id,
+        object? id,
         GeoObject geometry,
         GeoBoundingBox? boundingBox,
         IReadOnlyDictionary<string, object?> properties,
@@ -34,6 +34,11 @@ public sealed class GeoFeature : GeoObject
         ArgumentNullException.ThrowIfNull( properties, nameof( properties ) );
         ArgumentNullException.ThrowIfNull( customProperties, nameof( customProperties ) );
 
+        if ( id != null && !( id is string || id is int || id is long ) )
+        {
+            throw new ArgumentException( "Id must be a string or a number." );
+        }
+
         Id = id;
         Geometry = geometry;
         Properties = properties;
@@ -42,7 +47,7 @@ public sealed class GeoFeature : GeoObject
     /// <summary>
     /// Gets the identifier.
     /// </summary>
-    public string? Id { get; }
+    public object? Id { get; }
 
     /// <summary>
     /// Gets the geometry.

--- a/tests/GeoJsonSerializationTests.cs
+++ b/tests/GeoJsonSerializationTests.cs
@@ -311,6 +311,40 @@ public class GeoJsonSerializationTests
     [Theory]
     [InlineData( 2 )]
     [InlineData( 3 )]
+    public void CanRoundTripFeatureWithId( int _points )
+    {
+        var p = new PositionHelper( _points );
+
+        var input = $"{{ \"type\": \"Feature\", \"geometry\": {{ \"type\": \"Point\", \"coordinates\": [{p.PS(0)}] }}, \"properties\": {{ \"name\": \"value\" }}, \"id\": \"1\" }}";
+
+        var feature = AssertRoundTrip<GeoFeature>( input );
+        var point = Assert.IsType<GeoPoint>( feature.Geometry );
+
+        Assert.Equal( p.P(0), point.Coordinates );
+        Assert.Equal( "value", feature.Properties["name"] );
+        Assert.Equal( "1", feature.Id );
+    }
+
+    [Theory]
+    [InlineData( 2 )]
+    [InlineData( 3 )]
+    public void CanRoundTripFeatureWithNumberId( int _points )
+    {
+        var p = new PositionHelper( _points );
+
+        var input = $"{{ \"type\": \"Feature\", \"geometry\": {{ \"type\": \"Point\", \"coordinates\": [{p.PS(0)}] }}, \"properties\": {{ \"name\": \"value\" }}, \"id\": 1 }}";
+
+        var feature = AssertRoundTrip<GeoFeature>( input );
+        var point = Assert.IsType<GeoPoint>( feature.Geometry );
+
+        Assert.Equal( p.P(0), point.Coordinates );
+        Assert.Equal( "value", feature.Properties["name"] );
+        Assert.Equal( 1, feature.Id );
+    }
+
+    [Theory]
+    [InlineData( 2 )]
+    [InlineData( 3 )]
     public void CanRoundTripFeatureCollection( int _points )
     {
         var p = new PositionHelper( _points );


### PR DESCRIPTION
The property is now an object but serialization is limited to string and number.